### PR TITLE
Create endpoint for storing new API Secret

### DIFF
--- a/server/src/controllers/usersController.ts
+++ b/server/src/controllers/usersController.ts
@@ -37,8 +37,8 @@ const handleSecret = async (req: Request, res: Response) => {
     }
 
     res.status(201).json({ message: `Created new secret` })
-  } catch (error) {
-    res.status(400).json({ message: 'Invalid secret received' })
+  } catch (error: any) {
+    res.status(400).json({ message: error.message })
   }
 }
 

--- a/server/src/controllers/usersController.ts
+++ b/server/src/controllers/usersController.ts
@@ -1,11 +1,11 @@
 import type { Request, Response } from 'express'
-import bcrypt from 'bcrypt'
 import expressAsyncHandler from 'express-async-handler'
+
 import User from '../models/User.model'
+import { createSecret } from '../services/user.service'
 
 const getUser = expressAsyncHandler(
   async (req: Request, res: Response): Promise<void> => {
-    // const user = await User.find().select('-password').lean()
     const { id } = req.body
     const user = await User.findById(id).exec()
 
@@ -17,49 +17,29 @@ const getUser = expressAsyncHandler(
   }
 )
 
-// @desc Create new Client Key
-// @route POST /users
+// @desc Create new Client API Key
+// @route POST /user/secrets
 // @access Private
-const createNewUser = expressAsyncHandler(
-  async (req: Request, res: Response): Promise<void> => {
-    const { email, username, password } = req.body
+const handleSecret = async (req: Request, res: Response) => {
+  const { email, username, secrets } = req.body
 
-    // Confirm data
-    if (!email || !username || !password) {
-      res.status(400).json({ message: 'All fields are required' })
-      return
-    }
-
-    // Check for duplicates
-    const duplicate = await User.findOne({ email }).lean().exec()
-
-    if (duplicate) {
-      res.status(409).json({ message: 'Duplicate user' })
-      return
-    }
-
-    // Hash password
-    const hashedPassword: string = await bcrypt.hash(password, 10) // salt rounds
-
-    const userObject: {
-      email: string
-      username: string
-      password: string
-    } = {
-      email,
-      username,
-      password: hashedPassword,
-    }
-
-    // Create and store new user
-    const user = await User.create(userObject)
-
-    if (user) {
-      res.status(201).json({ message: `Created new user - ${username}` })
-    } else {
-      res.status(400).json({ message: 'Invalid user data received' })
-    }
+  // Confirm data
+  if (!email || !username || !secrets) {
+    res.status(400).json({ message: 'All fields are required' })
+    return
   }
-)
 
-export { getUser, createNewUser }
+  try {
+    const createdSecret = await createSecret(req.body)
+
+    if (!createdSecret) {
+      return res.status(400).send('Secret creation failed')
+    }
+
+    res.status(201).json({ message: `Created new secret` })
+  } catch (error) {
+    res.status(400).json({ message: 'Invalid secret received' })
+  }
+}
+
+export { getUser, handleSecret }

--- a/server/src/models/User.model.ts
+++ b/server/src/models/User.model.ts
@@ -1,11 +1,17 @@
 import bcrypt from 'bcrypt'
 import { Document, model, Schema } from 'mongoose'
 
+export interface APISecret {
+  description: string
+  label: string
+  secret: string
+}
+
 export interface UserSchema extends Document {
   email: string
   username: string
   password: string
-  secrets: string[]
+  secrets: Array<APISecret>
   shelf: string[]
   guest: boolean
   active: boolean
@@ -62,19 +68,11 @@ const userSchema = new Schema<UserSchema>({
 })
 
 const saltRounds: number = 10
-const secretSaltRounds: number = 8
 
 userSchema.pre('save', async function (next) {
   const user = this
   if (user.isModified('password')) {
     user.password = await bcrypt.hash(user.password, saltRounds)
-  }
-
-  if (user.isModified('secrets')) {
-    user.secrets.map(async (secret: string) => {
-      const hashedSecret = await bcrypt.hash(secret, secretSaltRounds)
-      user.secrets.push(hashedSecret)
-    })
   }
 })
 

--- a/server/src/models/User.model.ts
+++ b/server/src/models/User.model.ts
@@ -62,11 +62,19 @@ const userSchema = new Schema<UserSchema>({
 })
 
 const saltRounds: number = 10
+const secretSaltRounds: number = 8
 
 userSchema.pre('save', async function (next) {
   const user = this
   if (user.isModified('password')) {
     user.password = await bcrypt.hash(user.password, saltRounds)
+  }
+
+  if (user.isModified('secrets')) {
+    user.secrets.map(async (secret: string) => {
+      const hashedSecret = await bcrypt.hash(secret, secretSaltRounds)
+      user.secrets.push(hashedSecret)
+    })
   }
 })
 

--- a/server/src/routes/user.route.ts
+++ b/server/src/routes/user.route.ts
@@ -1,11 +1,8 @@
-import { config } from 'dotenv'
 import { Router } from 'express'
 import { expressjwt } from 'express-jwt'
 import { Secret } from 'jsonwebtoken'
 
 import { getUser, handleSecret } from '../controllers/usersController'
-
-config()
 
 const jwtSecret = process.env.ACCESS_TOKEN_SECRET as Secret
 

--- a/server/src/routes/user.route.ts
+++ b/server/src/routes/user.route.ts
@@ -3,7 +3,7 @@ import { Router } from 'express'
 import { expressjwt } from 'express-jwt'
 import { Secret } from 'jsonwebtoken'
 
-import { getUser } from '../controllers/usersController'
+import { getUser, handleSecret } from '../controllers/usersController'
 
 config()
 
@@ -16,6 +16,11 @@ router.get(
   '/:id',
   expressjwt({ secret: jwtSecret, algorithms: ['HS256'] }),
   getUser
+)
+router.post(
+  '/secrets',
+  expressjwt({ secret: jwtSecret, algorithms: ['HS256'] }),
+  handleSecret
 )
 
 export = router

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -1,0 +1,29 @@
+import { DocumentDefinition } from 'mongoose'
+
+import User, { UserSchema } from '../models/User.model'
+
+const createSecret = async (user: DocumentDefinition<UserSchema>) => {
+  try {
+    const foundUser = await User.findOne({ email: user.email }).exec()
+
+    if (!foundUser) {
+      throw new Error('Email is incorrect')
+    }
+
+    const duplicate = await User.find({
+      'secrets.secret': user.secrets,
+    })
+
+    if (duplicate) {
+      throw new Error('Provided API Key already saved')
+    }
+    foundUser?.secrets.push(user.secrets[0])
+    await foundUser.save()
+
+    return 'Secret created'
+  } catch (error) {
+    throw error
+  }
+}
+
+export { createSecret }


### PR DESCRIPTION
## Backend endpoint with POST route to store API Secret

The string that stores API Key is encrypted and stored in MongoDB User Document
Duplicate keys are disallowed and will be reused in frontend actions or individual Panaceum bottles

The POST Request requires a JWT

## NOTE
Will add verification for API Keys from Notion or Todoist